### PR TITLE
Update for Bootstrap v4

### DIFF
--- a/src/row.js
+++ b/src/row.js
@@ -71,6 +71,7 @@ var Row = React.createClass({
         };
 
         if (this.props.layout === 'horizontal') {
+            classNames.formGroup.push('row');
             classNames.elementWrapper.push('col-sm-9');
         }
 


### PR DESCRIPTION
Hello,

I'm using this library with Bootstrap v4, and I noticed a small change: The margins around the `Row` element disappeared, because of [a change in Bootstrap](http://v4-alpha.getbootstrap.com/migration/#forms).

I've added the required CSS class to the `Row` element. It still works with Bootstrap v3.