### PR TITLE
Allow a node to supplied for the label so the user can add elements.

### DIFF
--- a/release/row.js
+++ b/release/row.js
@@ -9,7 +9,7 @@ var Row = React.createClass({
     displayName: 'Row',
 
     propTypes: {
-        label: React.PropTypes.string,
+        label: React.PropTypes.node,
         rowClassName: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array, React.PropTypes.object]),
         labelClassName: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array, React.PropTypes.object]),
         elementWrapperClassName: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array, React.PropTypes.object]),

--- a/src/row.js
+++ b/src/row.js
@@ -8,7 +8,7 @@ var classNames = require('classnames/dedupe');
 var Row = React.createClass({
 
     propTypes: {
-        label: React.PropTypes.string,
+        label: React.PropTypes.node,
         rowClassName: React.PropTypes.oneOfType([
             React.PropTypes.string,
             React.PropTypes.array,


### PR DESCRIPTION
This allows the user to add elements such as tooltips to the labels. 

There is one caveat that the user has to supply a id props so that we don't try and stringify the props.  In the getId function of the component.js mixins 