### PR TITLE
Add basic support for input group addons

### DIFF
--- a/release/input.js
+++ b/release/input.js
@@ -16,12 +16,16 @@ var Input = React.createClass({
     mixins: [Formsy.Mixin, ComponentMixin],
 
     propTypes: {
-        type: React.PropTypes.oneOf(['color', 'date', 'datetime', 'datetime-local', 'email', 'hidden', 'month', 'number', 'password', 'range', 'search', 'tel', 'text', 'time', 'url', 'week'])
+        type: React.PropTypes.oneOf(['color', 'date', 'datetime', 'datetime-local', 'email', 'hidden', 'month', 'number', 'password', 'range', 'search', 'tel', 'text', 'time', 'url', 'week']),
+        addonBefore: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.node]),
+        addonAfter: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.node])
     },
 
     getDefaultProps: function getDefaultProps() {
         return {
-            type: 'text'
+            type: 'text',
+            addonBefore: null,
+            addonAfter: null
         };
     },
 
@@ -34,7 +38,15 @@ var Input = React.createClass({
     render: function render() {
         var element = this.renderElement();
 
-        if (this.getLayout() === 'elementOnly' || this.props.type === 'hidden') {
+        if (this.props.type === 'hidden') {
+            return element;
+        }
+
+        if (this.props.addonBefore || this.props.addonAfter) {
+            element = this.renderInputGroup(element);
+        }
+
+        if (this.getLayout() === 'elementOnly') {
             return element;
         }
 
@@ -69,6 +81,28 @@ var Input = React.createClass({
             onChange: this.changeValue,
             disabled: this.isFormDisabled() || this.props.disabled
         }));
+    },
+
+    renderInputGroup: function renderInputGroup(element) {
+        return React.createElement(
+            'div',
+            { className: 'input-group' },
+            this.renderAddon(this.props.addonBefore),
+            element,
+            this.renderAddon(this.props.addonAfter)
+        );
+    },
+
+    renderAddon: function renderAddon(addon) {
+        if (!addon) {
+            return '';
+        } else {
+            return React.createElement(
+                'span',
+                { className: 'input-group-addon' },
+                addon
+            );
+        }
     }
 
 });

--- a/src/input.js
+++ b/src/input.js
@@ -30,12 +30,22 @@ var Input = React.createClass({
             'time',
             'url',
             'week'
+        ]),
+        addonBefore: React.PropTypes.oneOfType([
+            React.PropTypes.string,
+            React.PropTypes.node
+        ]),
+        addonAfter: React.PropTypes.oneOfType([
+            React.PropTypes.string,
+            React.PropTypes.node
         ])
     },
 
     getDefaultProps: function() {
         return {
-            type: 'text'
+            type: 'text',
+            addonBefore: null,
+            addonAfter: null
         };
     },
 
@@ -48,7 +58,15 @@ var Input = React.createClass({
     render: function() {
         var element = this.renderElement();
 
-        if (this.getLayout() === 'elementOnly' || this.props.type === 'hidden') {
+        if (this.props.type === 'hidden') {
+            return element;
+        }
+
+        if (this.props.addonBefore || this.props.addonAfter) {
+            element = this.renderInputGroup(element);
+        }
+
+        if (this.getLayout() === 'elementOnly') {
             return element;
         }
 
@@ -88,6 +106,24 @@ var Input = React.createClass({
                 disabled={this.isFormDisabled() || this.props.disabled}
             />
         );
+    },
+
+    renderInputGroup: function(element) {
+        return (
+            <div className="input-group">
+                {this.renderAddon(this.props.addonBefore)}
+                {element}
+                {this.renderAddon(this.props.addonAfter)}
+            </div>
+        );
+    },
+
+    renderAddon: function(addon) {
+        if(!addon) {
+            return '';
+        } else {
+            return <span className="input-group-addon">{addon}</span>;
+        }
     }
 
 });


### PR DESCRIPTION
This adds the ability to add addons to input fields (see: http://getbootstrap.com/components/#input-groups-basic).

This commit adds two props to the Input component: addonBefore and addonAfter.
Both can either be a string or a renderable element (PropType node).

Example:

        let beforeElement = (<span className="glyphicon glyphicon-search"></span>);

        <Input
              {...sharedProps}
              name="amount"
              id="amount"
              label="How much was paid?"
              addonBefore={beforeElement}
              addonAfter="Just a string" />

Caveats:
* When using an element as addon one HAS to provide an Id, or else the getId method in the component mixin will produce an error when JSON stringifying the props (see: https://github.com/twisty/formsy-react-components/issues/33).
* When using addonAfter, addtional styling for the Input component may be necessary to correctly display the error icon.