### PR TITLE
Input addons: fix round corners

### DIFF
--- a/release/input.js
+++ b/release/input.js
@@ -95,7 +95,7 @@ var Input = React.createClass({
 
     renderAddon: function renderAddon(addon) {
         if (!addon) {
-            return '';
+            return false;
         } else {
             return React.createElement(
                 'span',

--- a/src/input.js
+++ b/src/input.js
@@ -120,7 +120,7 @@ var Input = React.createClass({
 
     renderAddon: function(addon) {
         if(!addon) {
-            return '';
+            return false;
         } else {
             return <span className="input-group-addon">{addon}</span>;
         }


### PR DESCRIPTION
The bootstrap class does not apply, because it renders a blank <span>