### PR TITLE
Replace old-style string refs with new-style callback refs

### DIFF
--- a/release/checkbox-group.js
+++ b/release/checkbox-group.js
@@ -12,6 +12,7 @@ var Row = require('./row');
 var CheckboxGroup = React.createClass({
     displayName: 'CheckboxGroup',
 
+
     mixins: [Formsy.Mixin, ComponentMixin],
 
     propTypes: {
@@ -28,11 +29,11 @@ var CheckboxGroup = React.createClass({
 
     changeCheckbox: function changeCheckbox() {
         var value = [];
-        this.props.options.forEach((function (option, key) {
-            if (this.refs['element-' + key].checked) {
+        this.props.options.forEach(function (option, key) {
+            if (this['element-' + key].checked) {
                 value.push(option.value);
             }
-        }).bind(this));
+        }.bind(this));
         this.setValue(value);
         this.props.onChange(this.props.name, value);
     },
@@ -50,7 +51,9 @@ var CheckboxGroup = React.createClass({
                     'label',
                     null,
                     React.createElement('input', {
-                        ref: 'element-' + key,
+                        ref: function ref(c) {
+                            return _this['element-' + key] = c;
+                        },
                         checked: checked,
                         type: 'checkbox',
                         value: checkbox.value,

--- a/release/checkbox.js
+++ b/release/checkbox.js
@@ -12,6 +12,7 @@ var Row = require('./row');
 var Checkbox = React.createClass({
     displayName: 'Checkbox',
 
+
     mixins: [Formsy.Mixin, ComponentMixin],
 
     getDefaultProps: function getDefaultProps() {
@@ -29,6 +30,8 @@ var Checkbox = React.createClass({
     },
 
     renderElement: function renderElement() {
+        var _this = this;
+
         return React.createElement(
             'div',
             { className: 'checkbox' },
@@ -36,7 +39,9 @@ var Checkbox = React.createClass({
                 'label',
                 null,
                 React.createElement('input', _extends({
-                    ref: 'element'
+                    ref: function ref(c) {
+                        return _this.element = c;
+                    }
                 }, this.props, {
                     id: this.getId(),
                     type: 'checkbox',

--- a/release/input-file.js
+++ b/release/input-file.js
@@ -13,6 +13,7 @@ var Icon = require('./icon');
 var File = React.createClass({
     displayName: 'File',
 
+
     mixins: [Formsy.Mixin, ComponentMixin],
 
     getInitialState: function getInitialState() {
@@ -54,8 +55,12 @@ var File = React.createClass({
     },
 
     renderElement: function renderElement() {
+        var _this = this;
+
         return React.createElement('input', _extends({
-            ref: 'element'
+            ref: function ref(c) {
+                return _this.element = c;
+            }
         }, this.props, {
             id: this.getId(),
             type: 'file',

--- a/release/input.js
+++ b/release/input.js
@@ -13,6 +13,7 @@ var Icon = require('./icon');
 var Input = React.createClass({
     displayName: 'Input',
 
+
     mixins: [Formsy.Mixin, ComponentMixin],
 
     propTypes: {
@@ -72,12 +73,16 @@ var Input = React.createClass({
     },
 
     renderElement: function renderElement() {
+        var _this = this;
+
         var className = 'form-control';
         if (['range'].indexOf(this.props.type) !== -1) {
             className = null;
         }
         return React.createElement('input', _extends({
-            ref: 'element',
+            ref: function ref(c) {
+                return _this.element = c;
+            },
             className: className
         }, this.props, {
             id: this.getId(),

--- a/release/radio-group.js
+++ b/release/radio-group.js
@@ -12,6 +12,7 @@ var Row = require('./row');
 var RadioGroup = React.createClass({
     displayName: 'RadioGroup',
 
+
     mixins: [Formsy.Mixin, ComponentMixin],
 
     propTypes: {
@@ -46,7 +47,9 @@ var RadioGroup = React.createClass({
                     'label',
                     { className: 'radio-inline', key: key },
                     React.createElement('input', {
-                        ref: 'element-' + key,
+                        ref: function ref(c) {
+                            return _this['element-' + key] = c;
+                        },
                         checked: checked,
                         type: 'radio',
                         value: radio.value,
@@ -64,7 +67,9 @@ var RadioGroup = React.createClass({
                     'label',
                     null,
                     React.createElement('input', {
-                        ref: 'element-' + key,
+                        ref: function ref(c) {
+                            return _this['element-' + key] = c;
+                        },
                         checked: checked,
                         type: 'radio',
                         value: radio.value,

--- a/release/row.js
+++ b/release/row.js
@@ -8,6 +8,7 @@ var classNames = require('classnames/dedupe');
 var Row = React.createClass({
     displayName: 'Row',
 
+
     propTypes: {
         label: React.PropTypes.node,
         rowClassName: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array, React.PropTypes.object]),

--- a/release/select.js
+++ b/release/select.js
@@ -4,6 +4,8 @@
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
 var React = require('react');
 var Formsy = require('formsy-react');
 var ComponentMixin = require('./mixins/component');
@@ -11,6 +13,7 @@ var Row = require('./row');
 
 var Select = React.createClass({
     displayName: 'Select',
+
 
     mixins: [Formsy.Mixin, ComponentMixin],
 
@@ -50,69 +53,65 @@ var Select = React.createClass({
     },
 
     renderElement: function renderElement() {
-		var options = this.props.options;
-        var groups = [];
+        var _this = this;
 
-        this.props.options.map(function (item) {
-            var exists = groups.some(function (it) {
-                return it == item.group;
-            });
-            if (item.group && item.group != "" && !exists) {
-                groups.push(item.group);
-            }
+        var renderOption = function renderOption(item, key) {
+            return React.createElement(
+                'option',
+                _extends({ key: key }, item, { label: null }),
+                item.label
+            );
+        };
+
+        var options = this.props.options;
+
+        var groups = options.filter(function (item) {
+            return item.group;
+        }).map(function (item) {
+            return item.group;
         });
+        // Get the unique items in group.
+        groups = [].concat(_toConsumableArray(new Set(groups)));
 
         var optionNodes = [];
 
         if (groups.length == 0) {
             optionNodes = options.map(function (item, index) {
-                return React.createElement(
-                    'option',
-                    _extends({ key: index }, item, { label: null }),
-                    item.label
-                );
+                return renderOption(item, index);
             });
         } else {
-			// For items without groups
-            var itemsWithoutGroup = options.filter(function (c) {
-                return !c.group || c.group == "";
-            })
-
-            itemsWithoutGroup.forEach(function (item, index) {
-                optionNodes.push(React.createElement(
-                        'option',
-                        _extends({ key: (index == 0 ? 1 * -1 : index * -1) }, item, { label: null }),
-                        item.label
-                    ));
+            // For items without groups.
+            var itemsWithoutGroup = options.filter(function (item) {
+                return !item.group;
             });
 
-            // For grouped items			
-            groups.forEach(function (group, indexGroup) {
-                var allItems = options.filter(function (c) {
-                    return c.group == group;
+            itemsWithoutGroup.forEach(function (item, index) {
+                optionNodes.push(renderOption(item, 'no-group-' + index));
+            });
+
+            groups.forEach(function (group, groupIndex) {
+
+                var groupItems = options.filter(function (item) {
+                    return item.group === group;
                 });
 
-                var itemsJsx = [];
-
-                allItems.forEach(function (item, index) {
-                    itemsJsx.push(React.createElement(
-                        'option',
-                        _extends({ key: index }, item, { label: null }),
-                        item.label
-                    ));
+                var groupOptionNodes = groupItems.map(function (item, index) {
+                    return renderOption(item, groupIndex + '-' + index);
                 });
 
                 optionNodes.push(React.createElement(
                     'optgroup',
-                    { key: indexGroup, label: group },
-                    itemsJsx
+                    { label: group, key: groupIndex },
+                    groupOptionNodes
                 ));
             });
         }
         return React.createElement(
             'select',
             _extends({
-                ref: 'element',
+                ref: function ref(c) {
+                    return _this.element = c;
+                },
                 className: 'form-control'
             }, this.props, {
                 id: this.getId(),

--- a/release/textarea.js
+++ b/release/textarea.js
@@ -12,6 +12,7 @@ var Row = require('./row');
 var Textarea = React.createClass({
     displayName: 'Textarea',
 
+
     mixins: [Formsy.Mixin, ComponentMixin],
 
     propTypes: {
@@ -33,8 +34,12 @@ var Textarea = React.createClass({
     },
 
     renderElement: function renderElement() {
+        var _this = this;
+
         return React.createElement('textarea', _extends({
-            ref: 'element',
+            ref: function ref(c) {
+                return _this.element = c;
+            },
             className: 'form-control'
         }, this.props, {
             id: this.getId(),

--- a/src/checkbox-group.js
+++ b/src/checkbox-group.js
@@ -26,7 +26,7 @@ var CheckboxGroup = React.createClass({
     changeCheckbox: function() {
         var value = [];
         this.props.options.forEach(function(option, key) {
-            if (this.refs['element-' + key].checked) {
+            if (this['element-' + key].checked) {
                 value.push(option.value);
             }
 
@@ -43,7 +43,7 @@ var CheckboxGroup = React.createClass({
                 <div className="checkbox" key={key}>
                     <label>
                         <input
-                            ref={'element-' + key}
+                            ref={(c) => this['element-' + key] = c}
                             checked={checked}
                             type="checkbox"
                             value={checkbox.value}

--- a/src/checkbox.js
+++ b/src/checkbox.js
@@ -30,7 +30,7 @@ var Checkbox = React.createClass({
             <div className="checkbox">
                 <label>
                     <input
-                        ref="element"
+                        ref={(c) => this.element = c}
                         {...this.props}
                         id={this.getId()}
                         type="checkbox"

--- a/src/input-file.js
+++ b/src/input-file.js
@@ -56,7 +56,7 @@ var File = React.createClass({
     renderElement: function() {
         return (
             <input
-                ref="element"
+                ref={(c) => this.element = c}
                 {...this.props}
                 id={this.getId()}
                 type="file"

--- a/src/input.js
+++ b/src/input.js
@@ -101,7 +101,7 @@ var Input = React.createClass({
         }
         return (
             <input
-                ref="element"
+                ref={(c) => this.element = c}
                 className={className}
                 {...this.props}
                 id={this.getId()}

--- a/src/radio-group.js
+++ b/src/radio-group.js
@@ -40,7 +40,7 @@ var RadioGroup = React.createClass({
                 return (
                     <label className="radio-inline" key={key}>
                         <input
-                            ref={'element-' + key}
+                            ref={(c) => this['element-' + key] = c}
                             checked={checked}
                             type="radio"
                             value={radio.value}
@@ -54,7 +54,7 @@ var RadioGroup = React.createClass({
                 <div className={className} key={key}>
                     <label>
                         <input
-                            ref={'element-' + key}
+                            ref={(c) => this['element-' + key] = c}
                             checked={checked}
                             type="radio"
                             value={radio.value}

--- a/src/select.js
+++ b/src/select.js
@@ -96,7 +96,7 @@ var Select = React.createClass({
         }
         return (
             <select
-                ref="element"
+                ref={(c) => this.element = c}
                 className="form-control"
                 {...this.props}
                 id={this.getId()}

--- a/src/textarea.js
+++ b/src/textarea.js
@@ -32,7 +32,7 @@ var Textarea = React.createClass({
     renderElement: function() {
         return (
             <textarea
-                ref="element"
+                ref={(c) => this.element = c}
                 className="form-control"
                 {...this.props}
                 id={this.getId()}


### PR DESCRIPTION
These were causing problems in my project, and according to react they
are soon to be deprecated anyway:

> Although string refs are not deprecated, they are considered legacy,
and will likely be deprecated at some point in the future. Callback
refs are preferred.

https://facebook.github.io/react/docs/more-about-refs.html

See the issue at: https://github.com/twisty/formsy-react-components/issues/76
