### PR TITLE
Add Validate on submit option

### DIFF
--- a/release/mixins/component.js
+++ b/release/mixins/component.js
@@ -7,6 +7,7 @@ module.exports = {
     propTypes: {
         layout: React.PropTypes.string,
         validatePristine: React.PropTypes.bool,
+        validateOnSubmit: React.PropTypes.bool,
         rowClassName: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array, React.PropTypes.object]),
         labelClassName: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array, React.PropTypes.object]),
         elementWrapperClassName: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array, React.PropTypes.object])
@@ -15,6 +16,7 @@ module.exports = {
     contextTypes: {
         layout: React.PropTypes.string,
         validatePristine: React.PropTypes.bool,
+        validateOnSubmit: React.PropTypes.bool,
         rowClassName: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array, React.PropTypes.object]),
         labelClassName: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array, React.PropTypes.object]),
         elementWrapperClassName: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array, React.PropTypes.object])
@@ -24,6 +26,7 @@ module.exports = {
         return {
             disabled: false,
             validatePristine: false,
+            validateOnSubmit: false,
             onChange: function onChange() {},
             onFocus: function onFocus() {},
             onBlur: function onBlur() {}
@@ -48,6 +51,11 @@ module.exports = {
     getValidatePristine: function getValidatePristine() {
         var defaultProperty = this.context.validatePristine || false;
         return this.props.validatePristine ? this.props.validatePristine : defaultProperty;
+    },
+
+    getValidateOnSubmit: function getValidateOnSubmit() {
+        var defaultProperty = this.context.validateOnSubmit || false;
+        return this.props.validateOnSubmit ? this.props.validateOnSubmit : defaultProperty;
     },
 
     getRowClassName: function getRowClassName() {
@@ -125,11 +133,12 @@ module.exports = {
     },
 
     showErrors: function showErrors() {
-        if (this.isPristine() === true) {
-            if (this.getValidatePristine() === false) {
-                return false;
-            }
+        if (this.isPristine() && !this.getValidatePristine()) {
+            return false;
         }
-        return this.isValid() === false;
+        if (this.validateOnSubmit() && !this.isFormSubmitted()) {
+            return false;
+        }
+        return !this.isValid();
     }
 };

--- a/release/mixins/component.js
+++ b/release/mixins/component.js
@@ -136,7 +136,7 @@ module.exports = {
         if (this.isPristine() && !this.getValidatePristine()) {
             return false;
         }
-        if (this.validateOnSubmit() && !this.isFormSubmitted()) {
+        if (this.getValidateOnSubmit() && !this.isFormSubmitted()) {
             return false;
         }
         return !this.isValid();

--- a/release/mixins/parent-context.js
+++ b/release/mixins/parent-context.js
@@ -5,6 +5,7 @@ var React = require('react');
 module.exports = {
 
     childContextTypes: {
+        validateOnSubmit: React.PropTypes.bool.isRequired,
         layout: React.PropTypes.string.isRequired,
         validatePristine: React.PropTypes.bool.isRequired,
         rowClassName: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array, React.PropTypes.object]),
@@ -14,6 +15,7 @@ module.exports = {
 
     getChildContext: function getChildContext() {
         return {
+            validateOnSubmit: this.props.validateOnSubmit || false,
             layout: this.props.layout || 'horizontal',
             validatePristine: this.props.validatePristine || false,
             rowClassName: this.props.rowClassName || '',

--- a/release/prop-utilities.js
+++ b/release/prop-utilities.js
@@ -35,7 +35,8 @@ var cleanProps = function cleanProps(props) {
         rowClassName = props.rowClassName,
         rowLabel = props.rowLabel,
         validatePristine = props.validatePristine,
-        rest = _objectWithoutProperties(props, ["mapping", "validationErrors", "onSubmit", "onValid", "onValidSubmit", "onInvalid", "onInvalidSubmit", "onChange", "reset", "preventExternalInvalidation", "onSuccess", "onError", "validationError", "validations", "addonAfter", "addonBefore", "buttonAfter", "buttonBefore", "elementWrapperClassName", "help", "label", "options", "labelClassName", "layout", "rowClassName", "rowLabel", "validatePristine"]);
+        validateOnSubmit = props.validateOnSubmit,
+        rest = _objectWithoutProperties(props, ["mapping", "validationErrors", "onSubmit", "onValid", "onValidSubmit", "onInvalid", "onInvalidSubmit", "onChange", "reset", "preventExternalInvalidation", "onSuccess", "onError", "validationError", "validations", "addonAfter", "addonBefore", "buttonAfter", "buttonBefore", "elementWrapperClassName", "help", "label", "options", "labelClassName", "layout", "rowClassName", "rowLabel", "validatePristine", "validateOnSubmit"]);
 
     return rest;
 };

--- a/src/mixins/component.js
+++ b/src/mixins/component.js
@@ -7,6 +7,7 @@ module.exports = {
     propTypes: {
         layout: React.PropTypes.string,
         validatePristine: React.PropTypes.bool,
+        validateOnSubmit: React.PropTypes.bool,
         rowClassName: React.PropTypes.oneOfType([
             React.PropTypes.string,
             React.PropTypes.array,
@@ -27,6 +28,7 @@ module.exports = {
     contextTypes: {
         layout: React.PropTypes.string,
         validatePristine: React.PropTypes.bool,
+        validateOnSubmit: React.PropTypes.bool,
         rowClassName: React.PropTypes.oneOfType([
             React.PropTypes.string,
             React.PropTypes.array,
@@ -48,6 +50,7 @@ module.exports = {
         return {
             disabled: false,
             validatePristine: false,
+            validateOnSubmit: false,
             onChange: function() {},
             onFocus: function() {},
             onBlur: function() {}
@@ -72,6 +75,11 @@ module.exports = {
     getValidatePristine: function() {
         var defaultProperty = this.context.validatePristine || false;
         return this.props.validatePristine ? this.props.validatePristine : defaultProperty;
+    },
+
+    getValidateOnSubmit: function() {
+        var defaultProperty = this.context.validateOnSubmit || false;
+        return this.props.validateOnSubmit ? this.props.validateOnSubmit : defaultProperty;
     },
 
     getRowClassName: function() {
@@ -149,11 +157,12 @@ module.exports = {
     },
 
     showErrors: function() {
-        if (this.isPristine() === true) {
-            if (this.getValidatePristine() === false) {
-                return false;
-            }
+        if (this.isPristine() && !this.getValidatePristine()) {
+            return false;
         }
-        return (this.isValid() === false);
+        if (this.validateOnSubmit() && !this.isFormSubmitted()) {
+            return false;
+        }
+        return !this.isValid();
     }
 };

--- a/src/mixins/component.js
+++ b/src/mixins/component.js
@@ -160,7 +160,7 @@ module.exports = {
         if (this.isPristine() && !this.getValidatePristine()) {
             return false;
         }
-        if (this.validateOnSubmit() && !this.isFormSubmitted()) {
+        if (this.getValidateOnSubmit() && !this.isFormSubmitted()) {
             return false;
         }
         return !this.isValid();

--- a/src/mixins/parent-context.js
+++ b/src/mixins/parent-context.js
@@ -5,6 +5,7 @@ var React = require('react');
 module.exports = {
 
     childContextTypes: {
+        validateOnSubmit: React.PropTypes.bool.isRequired,
         layout: React.PropTypes.string.isRequired,
         validatePristine: React.PropTypes.bool.isRequired,
         rowClassName: React.PropTypes.oneOfType([
@@ -26,6 +27,7 @@ module.exports = {
 
     getChildContext: function() {
         return {
+            validateOnSubmit: this.props.validateOnSubmit || false,
             layout: this.props.layout || 'horizontal',
             validatePristine: this.props.validatePristine || false,
             rowClassName: this.props.rowClassName || '',


### PR DESCRIPTION
This adds `validateOnSubmit` props, which is `false` by default, and can be set to `true`. When it's set to `true`, inputs doesn't show validation errors unless user attempted to submit form.