### PR TITLE
Pattern match updated to obtain name from props

### DIFF
--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -124,6 +124,7 @@ class Input extends React.Component<InputProps, State> {
       isPristine,
       value: propValue,
       blurCallback,
+      name,
     } = this.props;
     this.setState({currentValue: value});
     if (updateOnBlur) {


### PR DESCRIPTION
There seem to be a bug in `input` control where name of the target passed into `blurCallback` function is empty. 

This PR is to obtain the target name by pattern matching it from `props`.